### PR TITLE
Update to utilize the PageVisibility API instead of `focus` event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -364,6 +364,8 @@ function usePrimitiveFlags<F extends Flags>(
 
     let latestFetchId: number;
     const listener = async () => {
+      if (typeof document !== 'object' || document.visibilityState === 'hidden') return;
+                       
       const fetchId = (latestFetchId = Date.now());
 
       try {
@@ -390,9 +392,9 @@ function usePrimitiveFlags<F extends Flags>(
       }
     };
 
-    window.addEventListener('focus', listener);
+    window.addEventListener('visibilitychange', listener);
     return () => {
-      window.removeEventListener('focus', listener);
+      window.removeEventListener('visibilitychange', listener);
     };
   }, [revalidateOnFocus, setFlags, userAttributes]);
 


### PR DESCRIPTION
Hello 👋, I was looking into `@happykit/flags` implementation for the `revalidateOnFocus` I noticed that it utilizes `window.addEventListener('focus', ...)` for handling the focus. I found a few issues with this implementation:

- `iframe` can cause the focus event to fire numerous times if the user interacts with the `iframe` and then back with the current document
- DevTools can cause the `focus` event to fire numerous times if the user/developer interacts with the DevTools and then back with the document. (A very common case for developers)
- A developer fires a focus event (ie. `node.dispatchEvent(new CustomEvent('focus', { bubbles: true}))`). This case seems less likely but still a side-effect of the current implementation.
- 
I'm curious if you have considered utilizing the Page Visibility API to achieve a more true implementation for "refocus" of the window.

Thank you for taking the time to consider my suggestion!